### PR TITLE
Fixed issue with access_ok function 

### DIFF
--- a/DPO_RT5572_LinuxSTA_2.6.1.3_20121022/os/linux/sta_ioctl.c
+++ b/DPO_RT5572_LinuxSTA_2.6.1.3_20121022/os/linux/sta_ioctl.c
@@ -2600,7 +2600,7 @@ INT rt28xx_sta_ioctl(
 		case SIOCGIWPRIV:
 			if (wrqin->u.data.pointer) 
 			{
-				if ( access_ok(VERIFY_WRITE, wrqin->u.data.pointer, sizeof(privtab)) != TRUE)
+				if ( access_ok(wrqin->u.data.pointer, sizeof(privtab)) != TRUE)
 					break;
 				if ((sizeof(privtab) / sizeof(privtab[0])) <= wrq->u.data.length)
 				{
@@ -2613,7 +2613,7 @@ INT rt28xx_sta_ioctl(
 			}
 			break;
 		case RTPRIV_IOCTL_SET:
-			if(access_ok(VERIFY_READ, wrqin->u.data.pointer, wrqin->u.data.length) != TRUE)   
+			if(access_ok(wrqin->u.data.pointer, wrqin->u.data.length) != TRUE)   
 					break;
 			return rt_ioctl_setparam(net_dev, NULL, NULL, wrqin->u.data.pointer);
 			break;


### PR DESCRIPTION
access_ok function had the 1st argument (type) removed. Tested on Kernel 5.3.0